### PR TITLE
add unit test for runtime

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -5,9 +5,10 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "NODE_ENV=development nodemon index.ts",
-    "build": "npm run lint && node_modules/typescript/bin/tsc",
+    "build": "npm run lint && npm run test && node_modules/typescript/bin/tsc",
     "lint": "node_modules/tslint/bin/tslint -c tslint.json -p tsconfig.json --force",
-    "lint:fix": "node_modules/tslint/bin/tslint -c tslint.json -p tsconfig.json --fix --force"
+    "lint:fix": "node_modules/tslint/bin/tslint -c tslint.json -p tsconfig.json --fix --force",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -19,9 +20,38 @@
     "sqlite3": "^5.0.0"
   },
   "devDependencies": {
+    "@types/jest": "^26.0.19",
+    "jest": "^26.6.3",
     "nodemon": "2.0.4",
+    "ts-jest": "^26.4.4",
     "ts-node": "9.0.0",
     "tslint": "6.1.3",
     "typescript": "4.0.2"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "transform": {
+      "^.+\\.ts?$": "ts-jest"
+    },
+    "testMatch": [
+      "**/*.(test|spec).(ts)"
+    ],
+    "globals": {
+      "ts-jest": {
+        "tsConfig": "tsconfig.json"
+      }
+    },
+    "coveragePathIgnorePatterns": [
+      "/node_modules/"
+    ],
+    "coverageReporters": [
+      "json",
+      "lcov",
+      "text",
+      "text-summary"
+    ]
   }
 }

--- a/runtime/test/index.spec.ts
+++ b/runtime/test/index.spec.ts
@@ -1,0 +1,3 @@
+test("should return true", () => {
+  expect(true).toBe(true);
+});

--- a/runtime/tsconfig.json
+++ b/runtime/tsconfig.json
@@ -10,5 +10,5 @@
     "experimentalDecorators": true
   },
   "include": ["./**/*.ts", "./**/*.js"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "test"]
 }


### PR DESCRIPTION
This is a basic structure for runtime unit test.

I will complete other runtime modules unit test file as much as possible in the free time afterwards.

For the next function of runtime, I will write the test file first and then write the function.

All runtime unit tests will be executed before each build, no need to change the Makefile.