### PR TITLE
generate fn define for plain type return

### DIFF
--- a/examples/actor/src/lib.rs
+++ b/examples/actor/src/lib.rs
@@ -25,7 +25,8 @@ impl Actor for MyActor {
 
 #[mw_rt::actor::expose]
 impl MyActor {
-    pub fn return_int(&mut self) -> usize {
+    #[mw_rt::actor::method]
+    pub fn return_int(&mut self, _bytes1: &[u8]) -> usize {
         1
     }
 


### PR DESCRIPTION
If you declare a method signature like this: `pub fn return_int(&mut self, _bytes1: &[u8]) -> usize;`, `expose` macro will alse expand for runtime.